### PR TITLE
Add Dependabot security alert Slack notification workflow

### DIFF
--- a/.github/dependabot-slack-ignore.json
+++ b/.github/dependabot-slack-ignore.json
@@ -1,0 +1,3 @@
+{
+  "ignored_alerts": []
+}

--- a/.github/dependabot-slack-ignore.json
+++ b/.github/dependabot-slack-ignore.json
@@ -1,3 +1,0 @@
-{
-  "ignored_alerts": []
-}

--- a/.github/dependabot-slack-ignore.yml
+++ b/.github/dependabot-slack-ignore.yml
@@ -1,0 +1,1 @@
+ignored_alerts: []

--- a/.github/workflows/dependabot_slack_notification.yml
+++ b/.github/workflows/dependabot_slack_notification.yml
@@ -46,7 +46,16 @@ jobs:
             let ignoredAlerts = [];
             try {
               const raw = fs.readFileSync('.github/dependabot-slack-ignore.json', 'utf8');
-              ignoredAlerts = JSON.parse(raw).ignored_alerts || [];
+              const parsed = JSON.parse(raw).ignored_alerts || [];
+              ignoredAlerts = parsed.map(entry => {
+                if (typeof entry === 'object' && entry !== null) {
+                  if (!entry.id || !entry.reason) {
+                    core.warning(`Ignore list のエントリに id または reason がありません: ${JSON.stringify(entry)}`);
+                  }
+                  return String(entry.id);
+                }
+                return String(entry);
+              });
             } catch (e) {
               if (e.code !== 'ENOENT') {
                 core.warning(`Ignore list の読み込みに失敗しました: ${e.message}`);
@@ -82,7 +91,7 @@ jobs:
               if (!allowedSeverities.includes(severity)) return false;
 
               const ghsaId = a.security_advisory?.ghsa_id || '';
-              if (ignoredAlerts.includes(ghsaId)) return false;
+              if (ghsaId && ignoredAlerts.includes(ghsaId)) return false;
               if (ignoredAlerts.includes(String(a.number))) return false;
 
               return true;

--- a/.github/workflows/dependabot_slack_notification.yml
+++ b/.github/workflows/dependabot_slack_notification.yml
@@ -1,0 +1,185 @@
+name: Dependabot Slack Notification
+
+on:
+  schedule:
+    # critical/high: 毎日 9:00 JST (0:00 UTC)
+    - cron: "0 0 * * *"
+    # medium: 毎週月曜 9:00 JST
+    - cron: "0 0 * * 1"
+    # low: 毎月1日 9:00 JST
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+    inputs:
+      severity_filter:
+        description: "通知するセキュリティレベル (all / critical / high / medium / low)"
+        required: false
+        default: "all"
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Fetch Dependabot alerts and notify Slack
+        uses: actions/github-script@v7
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+
+            // --------------- 設定 ---------------
+            // スケジュール or 手動入力でフィルタを決定
+            const severityOrder = ['critical', 'high', 'medium', 'low'];
+
+            function getSeverityFilter() {
+              // workflow_dispatch の場合
+              const input = context.payload.inputs?.severity_filter;
+              if (input) return input;
+
+              // schedule の場合: cron の値で判定
+              const cron = context.payload.schedule;
+              if (cron === '0 0 * * *')  return 'critical,high';   // 毎日
+              if (cron === '0 0 * * 1')  return 'medium';          // 毎週
+              if (cron === '0 0 1 * *')  return 'low';             // 毎月
+              return 'all';
+            }
+
+            const filterStr = getSeverityFilter();
+            const allowedSeverities = filterStr === 'all'
+              ? severityOrder
+              : filterStr.split(',').map(s => s.trim());
+
+            // --------------- Ignore リスト読み込み ---------------
+            let ignoredAlerts = [];
+            try {
+              const raw = fs.readFileSync('.github/dependabot-slack-ignore.json', 'utf8');
+              ignoredAlerts = JSON.parse(raw).ignored_alerts || [];
+            } catch (_) {
+              // ファイルが無ければ無視
+            }
+
+            // --------------- アラート取得 ---------------
+            let alerts = [];
+            try {
+              const res = await github.rest.dependabot.listAlertsForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                per_page: 100,
+              });
+              alerts = res.data;
+            } catch (e) {
+              core.warning(`Dependabot alerts の取得に失敗しました: ${e.message}`);
+              return;
+            }
+
+            if (alerts.length === 0) {
+              core.info('オープンな Dependabot アラートはありません。');
+              return;
+            }
+
+            // --------------- フィルタリング ---------------
+            const filtered = alerts.filter(a => {
+              const severity = a.security_vulnerability?.severity?.toLowerCase()
+                || a.security_advisory?.severity?.toLowerCase()
+                || 'unknown';
+
+              // severity フィルタ
+              if (!allowedSeverities.includes(severity)) return false;
+
+              // ignore リスト (GHSA ID またはアラート番号で除外)
+              const ghsaId = a.security_advisory?.ghsa_id || '';
+              if (ignoredAlerts.includes(ghsaId)) return false;
+              if (ignoredAlerts.includes(a.number)) return false;
+
+              return true;
+            });
+
+            if (filtered.length === 0) {
+              core.info(`対象セキュリティレベル (${filterStr}) のアラートはありません。`);
+              return;
+            }
+
+            // --------------- Slack メッセージ構築 ---------------
+            const severityEmoji = {
+              critical: '🔴',
+              high:     '🟠',
+              medium:   '🟡',
+              low:      '🔵',
+            };
+
+            const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
+
+            const lines = filtered.map(a => {
+              const sev = a.security_vulnerability?.severity?.toLowerCase()
+                || a.security_advisory?.severity?.toLowerCase()
+                || 'unknown';
+              const emoji = severityEmoji[sev] || '⚪';
+              const pkg = a.security_vulnerability?.package?.name || 'unknown';
+              const summary = a.security_advisory?.summary || 'No summary';
+              const url = a.html_url;
+              return `${emoji} *[${sev.toUpperCase()}]* <${url}|#${a.number}> \`${pkg}\` - ${summary}`;
+            });
+
+            // severity ごとの件数サマリ
+            const counts = {};
+            filtered.forEach(a => {
+              const sev = a.security_vulnerability?.severity?.toLowerCase()
+                || a.security_advisory?.severity?.toLowerCase()
+                || 'unknown';
+              counts[sev] = (counts[sev] || 0) + 1;
+            });
+            const countSummary = Object.entries(counts)
+              .sort(([a], [b]) => severityOrder.indexOf(a) - severityOrder.indexOf(b))
+              .map(([sev, n]) => `${severityEmoji[sev] || '⚪'} ${sev}: ${n}`)
+              .join('  |  ');
+
+            const payload = {
+              blocks: [
+                {
+                  type: 'header',
+                  text: {
+                    type: 'plain_text',
+                    text: `🔒 Dependabot Security Alerts (${filtered.length} 件)`,
+                  },
+                },
+                {
+                  type: 'section',
+                  text: {
+                    type: 'mrkdwn',
+                    text: `*Repo:* <${repoUrl}|${context.repo.owner}/${context.repo.repo}>\n*Filter:* ${filterStr}\n*Summary:* ${countSummary}`,
+                  },
+                },
+                { type: 'divider' },
+                {
+                  type: 'section',
+                  text: {
+                    type: 'mrkdwn',
+                    text: lines.join('\n'),
+                  },
+                },
+              ],
+            };
+
+            // --------------- Slack 送信 ---------------
+            const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+            if (!webhookUrl) {
+              core.setFailed('SLACK_WEBHOOK_URL が設定されていません。');
+              return;
+            }
+
+            const resp = await fetch(webhookUrl, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(payload),
+            });
+
+            if (!resp.ok) {
+              core.setFailed(`Slack 送信失敗: ${resp.status} ${await resp.text()}`);
+            } else {
+              core.info(`Slack に ${filtered.length} 件のアラートを通知しました。`);
+            }

--- a/.github/workflows/dependabot_slack_notification.yml
+++ b/.github/workflows/dependabot_slack_notification.yml
@@ -58,12 +58,13 @@ jobs:
                   current.reason = reasonMatch[1].trim();
                 }
               }
-              ignoredAlerts = entries.map(entry => {
+              for (const entry of entries) {
                 if (!entry.id || !entry.reason) {
-                  core.warning(`Ignore list のエントリに id または reason がありません: ${JSON.stringify(entry)}`);
+                  core.setFailed(`Ignore list のエントリに id と reason は必須です: ${JSON.stringify(entry)}`);
+                  return;
                 }
-                return String(entry.id);
-              });
+                ignoredAlerts.push(String(entry.id));
+              }
             } catch (e) {
               if (e.code !== 'ENOENT') {
                 core.warning(`Ignore list の読み込みに失敗しました: ${e.message}`);

--- a/.github/workflows/dependabot_slack_notification.yml
+++ b/.github/workflows/dependabot_slack_notification.yml
@@ -25,17 +25,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Parse ignore list
+        id: ignore
+        run: |
+          FILE=".github/dependabot-slack-ignore.yml"
+          if [ -f "$FILE" ]; then
+            echo "json=$(yq -o=json '.' "$FILE")" >> "$GITHUB_OUTPUT"
+          else
+            echo 'json={"ignored_alerts":[]}' >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Fetch Dependabot alerts and notify Slack
         uses: actions/github-script@v7
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SEVERITY_FILTER: ${{ inputs.severity_filter }}
           MENTION: ${{ inputs.mention }}
+          IGNORE_LIST_JSON: ${{ steps.ignore.outputs.json }}
         with:
           github-token: ${{ secrets.DEPENDABOT_TOKEN }}
           script: |
-            const fs = require('fs');
-
             const severityOrder = ['critical', 'high', 'medium', 'low'];
             const filterStr = process.env.SEVERITY_FILTER || 'all';
             const allowedSeverities = filterStr === 'all'
@@ -45,19 +54,8 @@ jobs:
             // --------------- Ignore リスト読み込み ---------------
             let ignoredAlerts = [];
             try {
-              const raw = fs.readFileSync('.github/dependabot-slack-ignore.yml', 'utf8');
-              const entries = [];
-              let current = null;
-              for (const line of raw.split('\n')) {
-                const idMatch = line.match(/^\s*-?\s*id:\s*"?([^"]+)"?\s*$/);
-                const reasonMatch = line.match(/^\s*reason:\s*"?([^"]*)"?\s*$/);
-                if (idMatch) {
-                  current = { id: idMatch[1].trim() };
-                  entries.push(current);
-                } else if (reasonMatch && current) {
-                  current.reason = reasonMatch[1].trim();
-                }
-              }
+              const ignoreData = JSON.parse(process.env.IGNORE_LIST_JSON || '{}');
+              const entries = ignoreData.ignored_alerts || [];
               for (const entry of entries) {
                 if (!entry.id || !entry.reason) {
                   core.setFailed(`Ignore list のエントリに id と reason は必須です: ${JSON.stringify(entry)}`);
@@ -66,9 +64,8 @@ jobs:
                 ignoredAlerts.push(String(entry.id));
               }
             } catch (e) {
-              if (e.code !== 'ENOENT') {
-                core.warning(`Ignore list の読み込みに失敗しました: ${e.message}`);
-              }
+              core.setFailed(`Ignore list の JSON パースに失敗しました: ${e.message}`);
+              return;
             }
 
             // --------------- アラート取得 ---------------
@@ -201,11 +198,17 @@ jobs:
               return;
             }
 
-            const resp = await fetch(webhookUrl, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify(payload),
-            });
+            let resp;
+            try {
+              resp = await fetch(webhookUrl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+              });
+            } catch (e) {
+              core.setFailed(`Slack 送信中にエラーが発生しました: ${e.message}`);
+              return;
+            }
 
             if (!resp.ok) {
               core.setFailed(`Slack 送信失敗: ${resp.status} ${await resp.text()}`);

--- a/.github/workflows/dependabot_slack_notification.yml
+++ b/.github/workflows/dependabot_slack_notification.yml
@@ -7,6 +7,11 @@ on:
         description: "通知するセキュリティレベル (カンマ区切り: critical,high,medium,low / all)"
         required: true
         type: string
+      mention:
+        description: "Slack メンション先 (例: @channel, @here, <@U12345>, <!subteam^S12345>)"
+        required: false
+        type: string
+        default: ""
     secrets:
       SLACK_WEBHOOK_URL:
         required: true
@@ -23,6 +28,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SEVERITY_FILTER: ${{ inputs.severity_filter }}
+          MENTION: ${{ inputs.mention }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -116,6 +122,8 @@ jobs:
               .map(([sev, n]) => `${severityEmoji[sev] || '⚪'} ${sev}: ${n}`)
               .join('  |  ');
 
+            const mention = (process.env.MENTION || '').trim();
+
             const payload = {
               blocks: [
                 {
@@ -125,6 +133,13 @@ jobs:
                     text: `🔒 Dependabot Security Alerts (${filtered.length} 件)`,
                   },
                 },
+                ...(mention ? [{
+                  type: 'section',
+                  text: {
+                    type: 'mrkdwn',
+                    text: mention,
+                  },
+                }] : []),
                 {
                   type: 'section',
                   text: {

--- a/.github/workflows/dependabot_slack_notification.yml
+++ b/.github/workflows/dependabot_slack_notification.yml
@@ -15,6 +15,8 @@ on:
     secrets:
       SLACK_WEBHOOK_URL:
         required: true
+      DEPENDABOT_TOKEN:
+        required: true
 
 jobs:
   notify:
@@ -30,7 +32,7 @@ jobs:
           SEVERITY_FILTER: ${{ inputs.severity_filter }}
           MENTION: ${{ inputs.mention }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.DEPENDABOT_TOKEN }}
           script: |
             const fs = require('fs');
 
@@ -45,8 +47,10 @@ jobs:
             try {
               const raw = fs.readFileSync('.github/dependabot-slack-ignore.json', 'utf8');
               ignoredAlerts = JSON.parse(raw).ignored_alerts || [];
-            } catch (_) {
-              // ファイルが無ければ無視
+            } catch (e) {
+              if (e.code !== 'ENOENT') {
+                core.warning(`Ignore list の読み込みに失敗しました: ${e.message}`);
+              }
             }
 
             // --------------- アラート取得 ---------------
@@ -60,7 +64,7 @@ jobs:
               });
               alerts = res.data;
             } catch (e) {
-              core.warning(`Dependabot alerts の取得に失敗しました: ${e.message}`);
+              core.setFailed(`Dependabot alerts の取得に失敗しました: ${e.message}`);
               return;
             }
 
@@ -79,7 +83,7 @@ jobs:
 
               const ghsaId = a.security_advisory?.ghsa_id || '';
               if (ignoredAlerts.includes(ghsaId)) return false;
-              if (ignoredAlerts.includes(a.number)) return false;
+              if (ignoredAlerts.includes(String(a.number))) return false;
 
               return true;
             });
@@ -148,13 +152,27 @@ jobs:
                   },
                 },
                 { type: 'divider' },
-                {
-                  type: 'section',
-                  text: {
-                    type: 'mrkdwn',
-                    text: lines.join('\n'),
-                  },
-                },
+                ...(() => {
+                  const joined = lines.join('\n');
+                  if (joined.length <= 3000) {
+                    return [{ type: 'section', text: { type: 'mrkdwn', text: joined } }];
+                  }
+                  // Split into multiple sections within 3000 char limit
+                  const sections = [];
+                  let current = '';
+                  for (const line of lines) {
+                    if (current && (current + '\n' + line).length > 3000) {
+                      sections.push({ type: 'section', text: { type: 'mrkdwn', text: current } });
+                      current = line;
+                    } else {
+                      current = current ? current + '\n' + line : line;
+                    }
+                  }
+                  if (current) {
+                    sections.push({ type: 'section', text: { type: 'mrkdwn', text: current } });
+                  }
+                  return sections;
+                })(),
               ],
             };
 

--- a/.github/workflows/dependabot_slack_notification.yml
+++ b/.github/workflows/dependabot_slack_notification.yml
@@ -45,16 +45,24 @@ jobs:
             // --------------- Ignore リスト読み込み ---------------
             let ignoredAlerts = [];
             try {
-              const raw = fs.readFileSync('.github/dependabot-slack-ignore.json', 'utf8');
-              const parsed = JSON.parse(raw).ignored_alerts || [];
-              ignoredAlerts = parsed.map(entry => {
-                if (typeof entry === 'object' && entry !== null) {
-                  if (!entry.id || !entry.reason) {
-                    core.warning(`Ignore list のエントリに id または reason がありません: ${JSON.stringify(entry)}`);
-                  }
-                  return String(entry.id);
+              const raw = fs.readFileSync('.github/dependabot-slack-ignore.yml', 'utf8');
+              const entries = [];
+              let current = null;
+              for (const line of raw.split('\n')) {
+                const idMatch = line.match(/^\s*-?\s*id:\s*"?([^"]+)"?\s*$/);
+                const reasonMatch = line.match(/^\s*reason:\s*"?([^"]*)"?\s*$/);
+                if (idMatch) {
+                  current = { id: idMatch[1].trim() };
+                  entries.push(current);
+                } else if (reasonMatch && current) {
+                  current.reason = reasonMatch[1].trim();
                 }
-                return String(entry);
+              }
+              ignoredAlerts = entries.map(entry => {
+                if (!entry.id || !entry.reason) {
+                  core.warning(`Ignore list のエントリに id または reason がありません: ${JSON.stringify(entry)}`);
+                }
+                return String(entry.id);
               });
             } catch (e) {
               if (e.code !== 'ENOENT') {

--- a/.github/workflows/dependabot_slack_notification.yml
+++ b/.github/workflows/dependabot_slack_notification.yml
@@ -1,19 +1,15 @@
-name: Dependabot Slack Notification
+name: Dependabot Slack Notification (Reusable)
 
 on:
-  schedule:
-    # critical/high: 毎日 9:00 JST (0:00 UTC)
-    - cron: "0 0 * * *"
-    # medium: 毎週月曜 9:00 JST
-    - cron: "0 0 * * 1"
-    # low: 毎月1日 9:00 JST
-    - cron: "0 0 1 * *"
-  workflow_dispatch:
+  workflow_call:
     inputs:
       severity_filter:
-        description: "通知するセキュリティレベル (all / critical / high / medium / low)"
-        required: false
-        default: "all"
+        description: "通知するセキュリティレベル (カンマ区切り: critical,high,medium,low / all)"
+        required: true
+        type: string
+    secrets:
+      SLACK_WEBHOOK_URL:
+        required: true
 
 jobs:
   notify:
@@ -26,29 +22,14 @@ jobs:
         uses: actions/github-script@v7
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SEVERITY_FILTER: ${{ inputs.severity_filter }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
 
-            // --------------- 設定 ---------------
-            // スケジュール or 手動入力でフィルタを決定
             const severityOrder = ['critical', 'high', 'medium', 'low'];
-
-            function getSeverityFilter() {
-              // workflow_dispatch の場合
-              const input = context.payload.inputs?.severity_filter;
-              if (input) return input;
-
-              // schedule の場合: cron の値で判定
-              const cron = context.payload.schedule;
-              if (cron === '0 0 * * *')  return 'critical,high';   // 毎日
-              if (cron === '0 0 * * 1')  return 'medium';          // 毎週
-              if (cron === '0 0 1 * *')  return 'low';             // 毎月
-              return 'all';
-            }
-
-            const filterStr = getSeverityFilter();
+            const filterStr = process.env.SEVERITY_FILTER || 'all';
             const allowedSeverities = filterStr === 'all'
               ? severityOrder
               : filterStr.split(',').map(s => s.trim());
@@ -88,10 +69,8 @@ jobs:
                 || a.security_advisory?.severity?.toLowerCase()
                 || 'unknown';
 
-              // severity フィルタ
               if (!allowedSeverities.includes(severity)) return false;
 
-              // ignore リスト (GHSA ID またはアラート番号で除外)
               const ghsaId = a.security_advisory?.ghsa_id || '';
               if (ignoredAlerts.includes(ghsaId)) return false;
               if (ignoredAlerts.includes(a.number)) return false;
@@ -125,7 +104,6 @@ jobs:
               return `${emoji} *[${sev.toUpperCase()}]* <${url}|#${a.number}> \`${pkg}\` - ${summary}`;
             });
 
-            // severity ごとの件数サマリ
             const counts = {};
             filtered.forEach(a => {
               const sev = a.security_vulnerability?.severity?.toLowerCase()

--- a/.github/workflows/dependabot_slack_schedule.yml
+++ b/.github/workflows/dependabot_slack_schedule.yml
@@ -29,6 +29,7 @@ jobs:
       mention: "<!channel>"
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      DEPENDABOT_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
 
   weekly-medium:
     if: github.event_name == 'schedule' && github.event.schedule == '0 0 * * 1'
@@ -38,6 +39,7 @@ jobs:
       mention: "<!here>"
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      DEPENDABOT_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
 
   monthly-low:
     if: github.event_name == 'schedule' && github.event.schedule == '0 0 1 * *'
@@ -46,6 +48,7 @@ jobs:
       severity_filter: "low"
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      DEPENDABOT_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
 
   # ---------- 手動実行 ----------
   manual:
@@ -56,3 +59,4 @@ jobs:
       mention: ${{ inputs.mention }}
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      DEPENDABOT_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}

--- a/.github/workflows/dependabot_slack_schedule.yml
+++ b/.github/workflows/dependabot_slack_schedule.yml
@@ -1,0 +1,51 @@
+name: Dependabot Slack Notification (Scheduled)
+
+on:
+  schedule:
+    # critical/high: 毎日 9:00 JST (0:00 UTC)
+    - cron: "0 0 * * *"
+    # medium: 毎週月曜 9:00 JST
+    - cron: "0 0 * * 1"
+    # low: 毎月1日 9:00 JST
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+    inputs:
+      severity_filter:
+        description: "通知するセキュリティレベル (all / critical,high / medium / low)"
+        required: false
+        default: "all"
+
+jobs:
+  # ---------- スケジュール実行 ----------
+  daily-critical-high:
+    if: github.event_name == 'schedule' && github.event.schedule == '0 0 * * *'
+    uses: ./.github/workflows/dependabot_slack_notification.yml
+    with:
+      severity_filter: "critical,high"
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  weekly-medium:
+    if: github.event_name == 'schedule' && github.event.schedule == '0 0 * * 1'
+    uses: ./.github/workflows/dependabot_slack_notification.yml
+    with:
+      severity_filter: "medium"
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  monthly-low:
+    if: github.event_name == 'schedule' && github.event.schedule == '0 0 1 * *'
+    uses: ./.github/workflows/dependabot_slack_notification.yml
+    with:
+      severity_filter: "low"
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  # ---------- 手動実行 ----------
+  manual:
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/dependabot_slack_notification.yml
+    with:
+      severity_filter: ${{ inputs.severity_filter }}
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/dependabot_slack_schedule.yml
+++ b/.github/workflows/dependabot_slack_schedule.yml
@@ -14,6 +14,10 @@ on:
         description: "通知するセキュリティレベル (all / critical,high / medium / low)"
         required: false
         default: "all"
+      mention:
+        description: "Slack メンション先 (例: @channel, <@U12345>)"
+        required: false
+        default: ""
 
 jobs:
   # ---------- スケジュール実行 ----------
@@ -22,6 +26,7 @@ jobs:
     uses: ./.github/workflows/dependabot_slack_notification.yml
     with:
       severity_filter: "critical,high"
+      mention: "<!channel>"
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
@@ -30,6 +35,7 @@ jobs:
     uses: ./.github/workflows/dependabot_slack_notification.yml
     with:
       severity_filter: "medium"
+      mention: "<!here>"
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
@@ -47,5 +53,6 @@ jobs:
     uses: ./.github/workflows/dependabot_slack_notification.yml
     with:
       severity_filter: ${{ inputs.severity_filter }}
+      mention: ${{ inputs.mention }}
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
- Schedule-based severity filtering: critical/high daily, medium weekly, low monthly
- Manual trigger with severity filter input
- Ignore list via .github/dependabot-slack-ignore.json (GHSA ID or alert number)
- Rich Slack message with severity emoji, summary counts, and alert links

https://claude.ai/code/session_014XXVq7uKC5AAenFBJwH4qe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated Slack notifications for dependency alerts with scheduled (daily/weekly/monthly) and manual triggers, configurable severity filtering, optional mention support, and a repository-level ignore list for suppressing specific alerts. Notifications include summarized counts and detailed alert entries; long messages are split to meet Slack limits and failures are reported.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->