### PR TITLE
Trivyのスケジュール実行を停止

### DIFF
--- a/.github/workflows/trivy_scan.yml
+++ b/.github/workflows/trivy_scan.yml
@@ -1,13 +1,6 @@
-name: Trivy Scan (Scheduled)
+name: Trivy Scan
 
 on:
-  schedule:
-    # CRITICAL,HIGH: weekdays at 9:00 JST (0:00 UTC)
-    - cron: "0 0 * * 1-5"
-    # MEDIUM: weekly on Monday at 9:00 JST
-    - cron: "0 0 * * 1"
-    # LOW: monthly on 1st at 9:00 JST
-    - cron: "0 0 1 * *"
   workflow_dispatch:
     inputs:
       severity:
@@ -20,34 +13,7 @@ on:
         default: ""
 
 jobs:
-  # ---------- Scheduled runs ----------
-  daily-critical-high:
-    if: github.event_name == 'schedule' && github.event.schedule == '0 0 * * 1-5'
-    uses: ./.github/workflows/_trivy_scan.yml
-    with:
-      severity: "CRITICAL,HIGH"
-    secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  weekly-medium:
-    if: github.event_name == 'schedule' && github.event.schedule == '0 0 * * 1'
-    uses: ./.github/workflows/_trivy_scan.yml
-    with:
-      severity: "MEDIUM"
-    secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  monthly-low:
-    if: github.event_name == 'schedule' && github.event.schedule == '0 0 1 * *'
-    uses: ./.github/workflows/_trivy_scan.yml
-    with:
-      severity: "LOW"
-    secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  # ---------- Manual run ----------
   manual:
-    if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/_trivy_scan.yml
     with:
       severity: ${{ inputs.severity }}

--- a/.github/workflows/trivy_scan.yml
+++ b/.github/workflows/trivy_scan.yml
@@ -13,7 +13,34 @@ on:
         default: ""
 
 jobs:
+  # ---------- Scheduled runs ----------
+  daily-critical-high:
+    if: github.event_name == 'schedule' && github.event.schedule == '0 0 * * 1-5'
+    uses: ./.github/workflows/_trivy_scan.yml
+    with:
+      severity: "CRITICAL,HIGH"
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  weekly-medium:
+    if: github.event_name == 'schedule' && github.event.schedule == '0 0 * * 1'
+    uses: ./.github/workflows/_trivy_scan.yml
+    with:
+      severity: "MEDIUM"
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  monthly-low:
+    if: github.event_name == 'schedule' && github.event.schedule == '0 0 1 * *'
+    uses: ./.github/workflows/_trivy_scan.yml
+    with:
+      severity: "LOW"
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  # ---------- Manual run ----------
   manual:
+    if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/_trivy_scan.yml
     with:
       severity: ${{ inputs.severity }}


### PR DESCRIPTION
## Summary
- Trivyスキャンのスケジュール実行（平日毎日/毎週月曜/毎月1日）を削除
- `workflow_dispatch` による手動実行は引き続き利用可能

## Test plan
- [ ] ワークフローファイルのYAML構文が正しいことを確認
- [ ] Actions タブで手動実行（workflow_dispatch）が引き続き動作することを確認

https://claude.ai/code/session_01LTBFBTzGfmKwqHtXDdsj6e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated security scan workflow: renamed display label and removed scheduled triggers so the workflow no longer runs on a schedule. It can now only be started manually via workflow dispatch; existing scheduled job definitions remain but will not be auto-triggered. Manual inputs and notification settings are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->