### PR TITLE
Remove schedule triggers from Dependabot Slack notification workflow

### DIFF
--- a/.github/workflows/dependabot_slack_notification.yml
+++ b/.github/workflows/dependabot_slack_notification.yml
@@ -1,13 +1,6 @@
 name: Dependabot Slack Notification (Scheduled)
 
 on:
-  schedule:
-    # critical/high: weekdays at 9:00 JST (0:00 UTC)
-    - cron: "0 0 * * 1-5"
-    # medium: weekly on Monday at 9:00 JST
-    - cron: "0 0 * * 1"
-    # low: monthly on 1st at 9:00 JST
-    - cron: "0 0 1 * *"
   workflow_dispatch:
     inputs:
       severity_filter:


### PR DESCRIPTION
https://claude.ai/code/session_01QBDCQDTtTb2Rw8QtAvyc5V

# type 

pedri or gavi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automatic scheduled notifications for Dependabot updates. Notifications can still be triggered manually if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->